### PR TITLE
How to Leverage JavaFX to avoid cross-controller communication

### DIFF
--- a/src/main/java/edu/wpi/u/controllers/AdminToolsController.java
+++ b/src/main/java/edu/wpi/u/controllers/AdminToolsController.java
@@ -29,45 +29,15 @@ public class AdminToolsController {
         ArrayList<Node> nodes = App.graphService.getNodes();
         ArrayList<Edge> edges = App.graphService.getEdges();
 
-        for (int i = 0; i < nodes.size(); i++) {
-            Node currentNodeInfo = nodes.get(i);
-            FXMLLoader nodeLoader = new FXMLLoader(getClass().getResource("/edu/wpi/u/views/NodeListItem.fxml"));
-            AnchorPane node = nodeLoader.load();
-            NodeItemController controller = nodeLoader.getController();
-            controller.nodeID.setText(currentNodeInfo.getNodeID());
-            double XPos = (nodes.get(i).getCords()[0]);
-            double YPos = (nodes.get(i).getCords()[1]);
-            controller.nodeLocation.setText("(" + Double.toString(XPos) + ", " + Double.toString(YPos) + ")");
-            controller.x = Double.toString(XPos);
-            controller.y = Double.toString(YPos);
-            StringBuilder string = new StringBuilder("Adj Nodes: ");
-            Iterator<Node> it = currentNodeInfo.getAdjNodes().descendingIterator();
-            while (it.hasNext()) {
-                string.append(it.next().getNodeID()+", ");
-            }
-            String label = String.valueOf(string);
-            if(label.length() > 0) {
-                label = label.substring(0, label.length()-2);
-                controller.nodeAdj.setText(label);
-            }else{
-                controller.nodeAdj.setText("No Adjacent Nodes");
-            }
-            nodeList.getChildren().add(node);
+        for (Node node: nodes) {
+            nodeList.getChildren().add(new NodeItemController(node));
         }
 
-        //Edges
-        for (int i = 0; i < edges.size(); i++) {
-            Edge currentEdgeInfo = edges.get(i);
-            FXMLLoader edgeLoader = new FXMLLoader(getClass().getResource("/edu/wpi/u/views/EdgeListItem.fxml"));
-            AnchorPane edge = edgeLoader.load();
-            EdgeItemController controller = edgeLoader.getController();
-            controller.edgeID.setText(currentEdgeInfo.getEdgeID());
-            controller.startingNode.setText(currentEdgeInfo.getStartNode().getNodeID());
-            controller.endingNode.setText(currentEdgeInfo.getEndNode().getNodeID());
-            test.getChildren().add(edge);
+        for (Edge edge: edges) {
+            test.getChildren().add(new EdgeItemController(edge));
         }
 
-        App.AdminStorage.haveSelectedNode.addListener((observable, oldValue, newValue)  ->
+        AdminToolStorage.haveSelectedNode.addListener((observable, oldValue, newValue)  ->
         {
             if(AdminToolStorage.nodeIsSelected){
                 editNodeButton.setVisible(true);

--- a/src/main/java/edu/wpi/u/controllers/EdgeItemController.java
+++ b/src/main/java/edu/wpi/u/controllers/EdgeItemController.java
@@ -1,15 +1,20 @@
 package edu.wpi.u.controllers;
 
 import edu.wpi.u.App;
+import edu.wpi.u.algorithms.Edge;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ResourceBundle;
 import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.fxml.Initializable;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.VBox;
 
-public class EdgeItemController {
-
-    @FXML public AnchorPane edgeAnchor;
+public class EdgeItemController extends AnchorPane implements Initializable {
+    
     @FXML public Label edgeID;
     @FXML public Label startingNode;
     @FXML public Label endingNode;
@@ -17,16 +22,32 @@ public class EdgeItemController {
     @FXML public Button expandButton;
     @FXML public Button collapseButton;
 
+    private final Edge edge;
+    public EdgeItemController(Edge edge) throws IOException {
+        FXMLLoader edgeLoader = new FXMLLoader(getClass().getResource("/edu/wpi/u/views/EdgeListItem.fxml"));
+        edgeLoader.setRoot(this);
+        edgeLoader.setController(this);
+        edgeLoader.load();
+        this.edge = edge;
+    }
+
+    @Override
+    public void initialize(URL location, ResourceBundle resources) {
+        this.edgeID.setText(this.edge.getEdgeID());
+        this.startingNode.setText(this.edge.getStartNode().getNodeID());
+        this.endingNode.setText(this.edge.getEndNode().getNodeID());
+    }
+
     @FXML
     public void handleEdgeExpandButton() {
-        edgeAnchor.setPrefHeight(300);
+        this.setPrefHeight(300);
         extendedInfo.setVisible(true);
         expandButton.setVisible(false);
     }
 
     @FXML
     public void handleEdgeCollapseButton() {
-        edgeAnchor.setPrefHeight(100);
+        this.setPrefHeight(100);
         extendedInfo.setVisible(false);
         expandButton.setVisible(true);
     }
@@ -34,8 +55,8 @@ public class EdgeItemController {
     @FXML
     public void handleEdgeDeleteButton() {
         App.graphService.deleteEdge(edgeID.getText());
-        edgeAnchor.setPrefHeight(0);
-        edgeAnchor.setVisible(false);
+        this.setPrefHeight(0);
+        this.setVisible(false);
         //could be consider 'sloppy delete' on UI side until AdminTool is reloaded
     }
 
@@ -52,4 +73,5 @@ public class EdgeItemController {
 
         App.rightDrawerRoot.set( "/edu/wpi/u/views/ModifyEdge.fxml");
     }
+
 }

--- a/src/main/java/edu/wpi/u/controllers/NodeItemController.java
+++ b/src/main/java/edu/wpi/u/controllers/NodeItemController.java
@@ -1,36 +1,65 @@
 package edu.wpi.u.controllers;
 
 import edu.wpi.u.App;
+import edu.wpi.u.algorithms.Node;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ResourceBundle;
+import java.util.stream.Collectors;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
+import javafx.fxml.Initializable;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.VBox;
 
-public class NodeItemController {
+public class NodeItemController extends AnchorPane implements Initializable {
 
-    @FXML public AnchorPane nodeAnchor;
+  private final Node node;
     @FXML public Label nodeID;
     @FXML public Label nodeLocation;
     @FXML public Label nodeAdj;
     @FXML public Button expandButton;
     @FXML public Button collapseButton;
     @FXML public VBox extendedInfo;
-
     public String x;
     public String y;
 
+  public NodeItemController(Node node) throws IOException {
+    FXMLLoader nodeLoader = new FXMLLoader(getClass().getResource("/edu/wpi/u/views/NodeListItem.fxml"));
+    nodeLoader.setController(this);
+    nodeLoader.setRoot(this);
+    nodeLoader.load();
+    this.node = node;
+  }
+
+  @Override
+  public void initialize(URL location, ResourceBundle resources) {
+    nodeID.setText(node.getNodeID());
+    nodeLocation.setText(String.format("(%f, %f)", node.getCords()[0], node.getCords()[1]));
+    if (node.getAdjNodes()
+        .size() == 0) {
+      nodeAdj.setText("No Adjacent Nodes");
+    } else {
+      String adjNodes = "Adj Nodes: " + node.getAdjNodes()
+          .stream()
+          .map(Node::getNodeID)
+          .collect(Collectors.joining(", "));
+      nodeAdj.setText(adjNodes);
+    }
+  }
+
     @FXML
     public void handleNodeExpandButton() {
-        nodeAnchor.setPrefHeight(300);
+        this.setPrefHeight(300);
         extendedInfo.setVisible(true);
         expandButton.setVisible(false);
     }
 
     @FXML
     public void handleNodeCollapseButton() {
-        nodeAnchor.setPrefHeight(100);
+        this.setPrefHeight(100);
         extendedInfo.setVisible(false);
         expandButton.setVisible(true);
     }
@@ -38,8 +67,8 @@ public class NodeItemController {
     @FXML
     public void handleNodeDeleteButton() {
         App.graphService.deleteNode(nodeID.getText());
-        nodeAnchor.setPrefHeight(0);
-        nodeAnchor.setVisible(false);
+        this.setPrefHeight(0);
+        this.setVisible(false);
         //could be consider 'sloppy delete' on UI side until AdminTool is reloaded
     }
 
@@ -55,5 +84,6 @@ public class NodeItemController {
 
         App.rightDrawerRoot.set( "/edu/wpi/u/views/ModifyNode.fxml");
     }
+
 
 }

--- a/src/main/java/edu/wpi/u/models/AdminToolStorage.java
+++ b/src/main/java/edu/wpi/u/models/AdminToolStorage.java
@@ -13,7 +13,6 @@ public class AdminToolStorage {
     public static int xloc = 0;
     public static int yloc = 0;
 
-    public static NodeItemController selectedNode = new NodeItemController();
     public static SimpleIntegerProperty haveSelectedNode = new SimpleIntegerProperty(0);
     public static boolean nodeIsSelected = false;
 

--- a/src/main/resources/edu/wpi/u/views/EdgeListItem.fxml
+++ b/src/main/resources/edu/wpi/u/views/EdgeListItem.fxml
@@ -8,7 +8,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
-<AnchorPane fx:id="edgeAnchor" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="100.0" prefWidth="250.0" stylesheets="@css/RegularTheme.css" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="edu.wpi.u.controllers.EdgeItemController">
+<fx:root type="javafx.scene.layout.AnchorPane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="100.0" prefWidth="250.0" stylesheets="@css/RegularTheme.css" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="edu.wpi.u.controllers.EdgeItemController">
    <children>
       <Separator maxHeight="-Infinity" minHeight="-Infinity" prefHeight="10.0" prefWidth="200.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
       <HBox alignment="CENTER" prefHeight="50.0" prefWidth="250.0" />
@@ -50,4 +50,4 @@
          </children>
       </VBox>
    </children>
-</AnchorPane>
+</fx:root>

--- a/src/main/resources/edu/wpi/u/views/NodeListItem.fxml
+++ b/src/main/resources/edu/wpi/u/views/NodeListItem.fxml
@@ -8,7 +8,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
-<AnchorPane fx:id="nodeAnchor" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="100.0" prefWidth="250.0" styleClass="background" stylesheets="@css/RegularTheme.css" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="edu.wpi.u.controllers.NodeItemController">
+<fx:root type="javafx.scene.layout.AnchorPane" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="100.0" prefWidth="250.0" styleClass="background" stylesheets="@css/RegularTheme.css" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="edu.wpi.u.controllers.NodeItemController">
    <children>
       <Separator maxHeight="-Infinity" minHeight="-Infinity" prefHeight="10.0" prefWidth="200.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
       <VBox alignment="CENTER" prefHeight="100.0" prefWidth="250.0" spacing="10.0">
@@ -56,4 +56,4 @@
          </children>
       </VBox>
    </children>
-</AnchorPane>
+</fx:root>


### PR DESCRIPTION
In your AdminTool controller you were creating lists of nodes and edges. However, you were directly accessing the controllers rather than relying on an underlying model within the controller to set the labels. 

While the elements in question weren't going to change, in future iterations you may choose to (for example) change the node id to be a SimpleStringProperty so that you can then use JavaFX bindings on it. The way you had it before, the controller would have no knowledge of the underlying model and therefore wouldn't be able to utilize this change.

In addition to making it possible for the view to become reactive later on, it moves the logic for how data is displayed to the correct controller (the NodeItem rather than the AdminTool)

A keen eye will recognize this as very basic [dependency injection](https://github.com/WPISoftEng/SoftEngGuide/blob/master/DI/intro.md).
